### PR TITLE
Ensure Rapidoc reactivation includes beneficiary payload

### DIFF
--- a/src/app/api/asaas/webhook/route.ts
+++ b/src/app/api/asaas/webhook/route.ts
@@ -2,9 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/firebaseAdmin';
 import { getAsaasCustomer } from '@/lib/asaasService';
 import {
-  ensureBeneficiaryByCPF,
-  reactivateBeneficiary,
-} from '@/lib/rapidocService';
+  buildBeneficiaryPayload,
+  type BeneficiaryUserRecord,
+} from '@/lib/beneficiaryPayload';
+import { ensureBeneficiaryByCPF, reactivateBeneficiary } from '@/lib/rapidocService';
 
 const SECRET = process.env.ASAAS_WEBHOOK_SECRET || '';
 
@@ -38,10 +39,13 @@ export async function POST(req: NextRequest) {
     .get();
 
   let userRef = snapshot.empty ? null : snapshot.docs[0].ref;
-  let user = snapshot.empty ? null : snapshot.docs[0].data();
+  let user = snapshot.empty ? null : (snapshot.docs[0].data() as BeneficiaryUserRecord | null);
+  let asaasCustomer: Awaited<ReturnType<typeof getAsaasCustomer>> | null = null;
 
   if (!userRef) {
     const customer = await getAsaasCustomer(customerId);
+    asaasCustomer = customer;
+
     if (!customer?.cpfCnpj) {
       await db.collection('events').add({
         kind: 'webhook_missing_cpf',
@@ -69,7 +73,7 @@ export async function POST(req: NextRequest) {
     });
 
     userRef = created;
-    user = (await created.get()).data();
+    user = (await created.get()).data() as BeneficiaryUserRecord | null;
   }
 
   if (!userRef || !user) {
@@ -77,23 +81,17 @@ export async function POST(req: NextRequest) {
   }
 
   const cpfDigits = String(user.cpf || '').replace(/\D/g, '');
-  const basePayload = {
-    name: user.name,
+  const basePayload = buildBeneficiaryPayload({
     cpf: cpfDigits,
-    email: user.email || undefined,
-    phone: user.phone || undefined,
-    zipCode: user.zipCode || undefined,
-    address: user.address || undefined,
-    city: user.city || undefined,
-    state: user.state || undefined,
-    birthday: user.birthday || undefined,
-  };
+    user,
+    customer: asaasCustomer,
+  });
 
   if (ACTIVATION_EVENTS.has(type)) {
     const ensured = await ensureBeneficiaryByCPF(basePayload);
     if (ensured?.uuid) {
       try {
-        await reactivateBeneficiary(ensured.uuid);
+        await reactivateBeneficiary(ensured.uuid, basePayload);
       } catch (error) {
         console.error('[asaas/webhook] reactivate failed', ensured.uuid, error);
       }

--- a/src/app/api/checkout/finalizar/route.ts
+++ b/src/app/api/checkout/finalizar/route.ts
@@ -1,11 +1,10 @@
-﻿import axios from 'axios';
+import axios from 'axios';
 import { NextRequest, NextResponse } from 'next/server';
 import { asaas } from '@/lib/asaas';
 import { db } from '@/lib/firebaseAdmin';
-import {
-  ensureBeneficiaryByCPF,
-  reactivateBeneficiary,
-} from '@/lib/rapidocService';
+import { getAsaasCustomer } from '@/lib/asaasService';
+import { buildBeneficiaryPayload, type BeneficiaryUserRecord } from '@/lib/beneficiaryPayload';
+import { ensureBeneficiaryByCPF, reactivateBeneficiary } from '@/lib/rapidocService';
 import {
   type FinalizeRequestBody,
   type FinalizeResponseBody,
@@ -26,6 +25,7 @@ export async function POST(request: NextRequest) {
     const paymentResponse = await asaas.get(`/payments/${paymentId}`);
     const payment = paymentResponse.data as AsaasPayment;
     const status = payment.status;
+    const customerId = payment.customer;
 
     if (!PAYMENT_SUCCESS_STATUSES.includes(status as (typeof PAYMENT_SUCCESS_STATUSES)[number])) {
       return NextResponse.json<FinalizeResponseBody>(
@@ -37,39 +37,114 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    let asaasCustomer: Awaited<ReturnType<typeof getAsaasCustomer>> | null = null;
+
+    if (customerId) {
+      try {
+        asaasCustomer = await getAsaasCustomer(customerId);
+      } catch (error) {
+        console.error('[checkout/finalizar] failed to load asaas customer', customerId, error);
+      }
+    }
+
     const snapshot = await db.collection('users').where('cpf', '==', cpfDigits).limit(1).get();
 
     let userRef = snapshot.empty ? null : snapshot.docs[0].ref;
+    let user = snapshot.empty ? null : (snapshot.docs[0].data() as Record<string, any>);
 
     if (!userRef) {
-      const created = await db.collection('users').add({
-        name: payment.customer ?? 'Cliente Asaas',
+      const createdPayload: Record<string, unknown> = {
+        name: asaasCustomer?.name ?? payment.customer ?? 'Cliente Asaas',
         cpf: cpfDigits,
-        email: null,
-        phone: null,
-        zipCode: null,
-        address: null,
-        city: null,
-        state: null,
-        asaasCustomerId: payment.customer ?? null,
+        email: asaasCustomer?.email ?? null,
+        phone: asaasCustomer?.mobilePhone ?? null,
+        zipCode: asaasCustomer?.postalCode ?? null,
+        address: asaasCustomer?.address ?? null,
+        city: asaasCustomer?.city ?? asaasCustomer?.cityName ?? null,
+        state: asaasCustomer?.state ?? null,
+        birthday: null,
+        paymentType: null,
+        serviceType: null,
+        holder: asaasCustomer?.cpfCnpj ?? null,
+        general: null,
+        asaasCustomerId: customerId ?? null,
         status: 'pending',
         beneficiaryUuid: null,
         createdAt: new Date(),
         updatedAt: new Date(),
-      });
+      };
+
+      const created = await db.collection('users').add(createdPayload);
       userRef = created;
+      user = createdPayload as Record<string, any>;
     }
 
-    const ensured = await ensureBeneficiaryByCPF({
-      name: payment.customer ?? 'Cliente Asaas',
+    if (!userRef) {
+      return NextResponse.json(
+        { error: 'Usuário não encontrado para sincronizar com a Rapidoc.' },
+        { status: 404 },
+      );
+    }
+
+    const updates: Record<string, unknown> = {};
+
+    if (customerId && (!user?.asaasCustomerId || user.asaasCustomerId !== customerId)) {
+      updates.asaasCustomerId = customerId;
+    }
+
+    const assignIfMissing = (key: string, value: unknown) => {
+      if (value == null || value === '') {
+        return;
+      }
+
+      if (!user || user[key] == null || user[key] === '') {
+        updates[key] = value;
+      }
+    };
+
+    if (asaasCustomer) {
+      assignIfMissing('name', asaasCustomer.name);
+      assignIfMissing('email', asaasCustomer.email ?? null);
+      assignIfMissing('phone', asaasCustomer.mobilePhone ?? null);
+      assignIfMissing('zipCode', asaasCustomer.postalCode ?? null);
+      assignIfMissing('address', asaasCustomer.address ?? null);
+      assignIfMissing('city', asaasCustomer.city ?? asaasCustomer.cityName ?? null);
+      assignIfMissing('state', asaasCustomer.state ?? null);
+      assignIfMissing('holder', asaasCustomer.cpfCnpj ?? null);
+    }
+
+    if (Object.keys(updates).length > 0) {
+      updates.updatedAt = new Date();
+      await userRef.update(updates);
+      user = { ...(user ?? {}), ...updates } as Record<string, any>;
+    }
+
+    const ensurePayload = buildBeneficiaryPayload({
       cpf: cpfDigits,
+      user: user as BeneficiaryUserRecord | null,
+      customer: asaasCustomer,
     });
+    const ensured = await ensureBeneficiaryByCPF(ensurePayload);
 
     if (ensured?.uuid) {
       try {
-        await reactivateBeneficiary(ensured.uuid);
+        await reactivateBeneficiary(ensured.uuid, ensurePayload);
       } catch (error) {
+        if (axios.isAxiosError(error)) {
+          const statusCode = error.response?.status ?? 502;
+          const backend = error.response?.data ?? null;
+          console.error('[checkout/finalizar] reactivate failed', ensured.uuid, statusCode, backend);
+          return NextResponse.json(
+            { error: 'Failed to reactivate beneficiary', backend },
+            { status: statusCode },
+          );
+        }
+
         console.error('[checkout/finalizar] reactivate failed', ensured.uuid, error);
+        return NextResponse.json(
+          { error: 'Failed to reactivate beneficiary' },
+          { status: 500 },
+        );
       }
 
       await userRef.update({

--- a/src/app/api/rapidoc/beneficiaries/[beneficiaryId]/reactivate/route.ts
+++ b/src/app/api/rapidoc/beneficiaries/[beneficiaryId]/reactivate/route.ts
@@ -1,8 +1,17 @@
 import { NextResponse } from 'next/server';
 import rapidoc from '@/lib/rapidoc';
 
+export async function PUT(request: Request, { params }: { params: { beneficiaryId: string } }) {
+  let payload: unknown = {};
 
-export async function PUT(_: Request, { params }: { params: { beneficiaryId: string } }) {
-const { data } = await rapidoc.put(`/beneficiaries/${params.beneficiaryId}/reactivate`, {});
-return NextResponse.json(data);
+  try {
+    const rawBody = await request.text();
+    payload = rawBody ? JSON.parse(rawBody) : {};
+  } catch (error) {
+    console.error('[rapidoc/reactivate] Failed to parse body', error);
+    payload = {};
+  }
+
+  const { data } = await rapidoc.put(`/beneficiaries/${params.beneficiaryId}/reactivate`, payload);
+  return NextResponse.json(data);
 }

--- a/src/lib/beneficiaryPayload.ts
+++ b/src/lib/beneficiaryPayload.ts
@@ -1,0 +1,89 @@
+import type { getAsaasCustomer } from '@/lib/asaasService';
+import type { BeneficiaryInput } from '@/lib/rapidocService';
+
+export type BeneficiaryUserRecord = {
+  name?: string | null;
+  cpf?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  zipCode?: string | null;
+  address?: string | null;
+  city?: string | null;
+  state?: string | null;
+  birthday?: string | null;
+  paymentType?: string | null;
+  serviceType?: string | null;
+  holder?: string | null;
+  general?: string | null;
+};
+
+export const digitsOnly = (value?: string | null) => {
+  if (!value) {
+    return undefined;
+  }
+
+  const numeric = String(value).replace(/\D/g, '');
+  return numeric || undefined;
+};
+
+type AsaasCustomer = Awaited<ReturnType<typeof getAsaasCustomer>>;
+
+type BuildPayloadArgs = {
+  cpf: string;
+  user?: BeneficiaryUserRecord | null;
+  customer?: AsaasCustomer | null;
+};
+
+export const buildBeneficiaryPayload = ({
+  cpf,
+  user,
+  customer,
+}: BuildPayloadArgs): BeneficiaryInput => {
+  const cpfDigits = digitsOnly(cpf) ?? cpf;
+
+  const payload: BeneficiaryInput = {
+    name: user?.name ?? customer?.name ?? 'Cliente Asaas',
+    cpf: cpfDigits,
+    paymentType: user?.paymentType ?? 'S',
+    serviceType: user?.serviceType ?? 'GS',
+    holder: digitsOnly(user?.holder ?? customer?.cpfCnpj ?? cpfDigits) ?? cpfDigits,
+    general: user?.general ?? 'General purpose',
+  };
+
+  const email = user?.email ?? customer?.email ?? undefined;
+  if (email) {
+    payload.email = email;
+  }
+
+  const phone = digitsOnly(user?.phone ?? customer?.mobilePhone ?? null);
+  if (phone) {
+    payload.phone = phone;
+  }
+
+  const zipCode = digitsOnly(user?.zipCode ?? customer?.postalCode ?? null);
+  if (zipCode) {
+    payload.zipCode = zipCode;
+  }
+
+  const address = user?.address ?? customer?.address ?? undefined;
+  if (address) {
+    payload.address = address;
+  }
+
+  const city = user?.city ?? customer?.city ?? customer?.cityName ?? undefined;
+  if (city) {
+    payload.city = city;
+  }
+
+  const state = user?.state ?? customer?.state ?? undefined;
+  if (state) {
+    payload.state = state;
+  }
+
+  const birthday = user?.birthday ?? undefined;
+  if (birthday) {
+    payload.birthday = birthday;
+  }
+
+  return payload;
+};

--- a/src/lib/rapidocService.ts
+++ b/src/lib/rapidocService.ts
@@ -10,6 +10,10 @@ export type BeneficiaryInput = {
   address?: string;
   city?: string;
   state?: string;
+  paymentType?: string;
+  serviceType?: string;
+  holder?: string;
+  general?: string;
 };
 
 export async function getBeneficiaryByCPF(cpf: string) {
@@ -24,8 +28,11 @@ export async function createBeneficiaryOne(payload: BeneficiaryInput) {
   return { raw: data, uuid };
 }
 
-export async function reactivateBeneficiary(beneficiaryId: string) {
-  const response = await rapidoc.put(`/beneficiaries/${beneficiaryId}/reactivate`, {});
+export async function reactivateBeneficiary(
+  beneficiaryId: string,
+  payload: BeneficiaryInput,
+) {
+  const response = await rapidoc.put(`/beneficiaries/${beneficiaryId}/reactivate`, payload);
   return response.data;
 }
 


### PR DESCRIPTION
## Summary
- add a reusable helper to build complete Rapidoc beneficiary payloads from user and Asaas data
- send the enriched payload when reactivating beneficiaries during manual finalize and webhook flows to avoid missing-field errors
- allow the internal Rapidoc reactivation endpoint and client to forward the payload required by the Rapidoc API

## Testing
- npm run build *(fails: Next.js could not download Google Fonts in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e33ef4fb8883289e017ae1a10b7351