### PR TITLE
Ensure Rapidoc reactivation includes beneficiary payload

### DIFF
--- a/src/app/(public)/assinante/pagar/page.tsx
+++ b/src/app/(public)/assinante/pagar/page.tsx
@@ -35,6 +35,11 @@ type CustomerForm = {
   address: string;
   city: string;
   state: string;
+  birthday: string;
+  paymentType: string;
+  serviceType: string;
+  holder: string;
+  general: string;
 };
 
 type CardForm = {
@@ -86,6 +91,19 @@ const extractErrorMessage = (error: unknown): string => {
   return error.message ?? 'Erro ao processar requisição';
 };
 
+const PAYMENT_TYPE_OPTIONS = [
+  { value: 'S', label: 'S - Recorrente' },
+  { value: 'A', label: 'A - Consulta' },
+];
+
+const SERVICE_TYPE_OPTIONS = [
+  { value: 'G', label: 'G - Clínico' },
+  { value: 'P', label: 'P - Psicologia' },
+  { value: 'GP', label: 'GP - Clínico + Psicologia' },
+  { value: 'GS', label: 'GS - Clínico + Especialistas' },
+  { value: 'GSP', label: 'GSP - Clínico + Especialistas + Psicologia' },
+];
+
 export default function PagarPage() {
   const [customer, setCustomer] = useState<CustomerForm>({
     name: '',
@@ -96,6 +114,11 @@ export default function PagarPage() {
     address: '',
     city: '',
     state: '',
+    birthday: '',
+    paymentType: PAYMENT_TYPE_OPTIONS[0]?.value ?? 'S',
+    serviceType: SERVICE_TYPE_OPTIONS[3]?.value ?? 'GS',
+    holder: '',
+    general: '',
   });
   const [method, setMethod] = useState<BillingType>(DEFAULT_METHOD);
   const [pixAvailable, setPixAvailable] = useState(true);
@@ -232,6 +255,34 @@ export default function PagarPage() {
       return null;
     }
 
+    const normalizedBirthday = customer.birthday.trim();
+    if (!normalizedBirthday) {
+      setError('Informe a data de nascimento.');
+      return null;
+    }
+
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(normalizedBirthday)) {
+      setError('Informe a data de nascimento no formato AAAA-MM-DD.');
+      return null;
+    }
+
+    const selectedPaymentType = customer.paymentType.trim().toUpperCase();
+    const paymentTypeOption = PAYMENT_TYPE_OPTIONS.find((option) => option.value === selectedPaymentType);
+    if (!paymentTypeOption) {
+      setError('Selecione um tipo de pagamento válido.');
+      return null;
+    }
+
+    const selectedServiceType = customer.serviceType.trim().toUpperCase();
+    const serviceTypeOption = SERVICE_TYPE_OPTIONS.find((option) => option.value === selectedServiceType);
+    if (!serviceTypeOption) {
+      setError('Selecione um tipo de serviço válido.');
+      return null;
+    }
+
+    const holderDigits = onlyDigits(customer.holder) || onlyDigits(customer.cpf);
+    const generalNotes = customer.general.trim();
+
     const parsedValue = parseCurrencyInput(amount);
     if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
       setError('Informe um valor válido.');
@@ -249,6 +300,11 @@ export default function PagarPage() {
       address: customer.address || undefined,
       city: customer.city || undefined,
       state: customer.state || undefined,
+      birthday: normalizedBirthday,
+      paymentType: paymentTypeOption.value,
+      serviceType: serviceTypeOption.value,
+      holder: holderDigits || undefined,
+      general: generalNotes || undefined,
       description: undefined,
     };
 
@@ -422,6 +478,17 @@ export default function PagarPage() {
             </div>
 
             <div className="grid gap-1">
+              <label className="text-sm font-medium">Data de nascimento</label>
+              <input
+                type="date"
+                className="rounded-md border px-3 py-2"
+                placeholder="2000-01-01"
+                value={customer.birthday}
+                onChange={(event) => handleCustomerChange('birthday', event.target.value)}
+              />
+            </div>
+
+            <div className="grid gap-1">
               <label className="text-sm font-medium">E-mail</label>
               <input
                 className="rounded-md border px-3 py-2"
@@ -478,6 +545,58 @@ export default function PagarPage() {
                   placeholder="SP"
                   value={customer.state}
                   onChange={(event) => handleCustomerChange('state', event.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-1 md:grid-cols-2">
+              <div className="grid gap-1">
+                <label className="text-sm font-medium">Tipo de pagamento Rapidoc</label>
+                <select
+                  className="rounded-md border px-3 py-2"
+                  value={customer.paymentType}
+                  onChange={(event) => handleCustomerChange('paymentType', event.target.value)}
+                >
+                  {PAYMENT_TYPE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="grid gap-1">
+                <label className="text-sm font-medium">Tipo de serviço Rapidoc</label>
+                <select
+                  className="rounded-md border px-3 py-2"
+                  value={customer.serviceType}
+                  onChange={(event) => handleCustomerChange('serviceType', event.target.value)}
+                >
+                  {SERVICE_TYPE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid gap-1 md:grid-cols-2">
+              <div className="grid gap-1">
+                <label className="text-sm font-medium">Titular do grupo (CPF)</label>
+                <input
+                  className="rounded-md border px-3 py-2"
+                  placeholder="CPF do titular"
+                  value={customer.holder}
+                  onChange={(event) => handleCustomerChange('holder', onlyDigits(event.target.value))}
+                />
+              </div>
+              <div className="grid gap-1">
+                <label className="text-sm font-medium">Campo geral (opcional)</label>
+                <input
+                  className="rounded-md border px-3 py-2"
+                  placeholder="Observações"
+                  value={customer.general}
+                  onChange={(event) => handleCustomerChange('general', event.target.value)}
                 />
               </div>
             </div>

--- a/src/app/api/asaas/webhook/route.ts
+++ b/src/app/api/asaas/webhook/route.ts
@@ -2,9 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/firebaseAdmin';
 import { getAsaasCustomer } from '@/lib/asaasService';
 import {
-  ensureBeneficiaryByCPF,
-  reactivateBeneficiary,
-} from '@/lib/rapidocService';
+  buildBeneficiaryPayload,
+  type BeneficiaryUserRecord,
+} from '@/lib/beneficiaryPayload';
+import { ensureBeneficiaryByCPF, reactivateBeneficiary } from '@/lib/rapidocService';
 
 const SECRET = process.env.ASAAS_WEBHOOK_SECRET || '';
 
@@ -38,10 +39,13 @@ export async function POST(req: NextRequest) {
     .get();
 
   let userRef = snapshot.empty ? null : snapshot.docs[0].ref;
-  let user = snapshot.empty ? null : snapshot.docs[0].data();
+  let user = snapshot.empty ? null : (snapshot.docs[0].data() as BeneficiaryUserRecord | null);
+  let asaasCustomer: Awaited<ReturnType<typeof getAsaasCustomer>> | null = null;
 
   if (!userRef) {
     const customer = await getAsaasCustomer(customerId);
+    asaasCustomer = customer;
+
     if (!customer?.cpfCnpj) {
       await db.collection('events').add({
         kind: 'webhook_missing_cpf',
@@ -69,7 +73,7 @@ export async function POST(req: NextRequest) {
     });
 
     userRef = created;
-    user = (await created.get()).data();
+    user = (await created.get()).data() as BeneficiaryUserRecord | null;
   }
 
   if (!userRef || !user) {
@@ -77,23 +81,17 @@ export async function POST(req: NextRequest) {
   }
 
   const cpfDigits = String(user.cpf || '').replace(/\D/g, '');
-  const basePayload = {
-    name: user.name,
+  const basePayload = buildBeneficiaryPayload({
     cpf: cpfDigits,
-    email: user.email || undefined,
-    phone: user.phone || undefined,
-    zipCode: user.zipCode || undefined,
-    address: user.address || undefined,
-    city: user.city || undefined,
-    state: user.state || undefined,
-    birthday: user.birthday || undefined,
-  };
+    user,
+    customer: asaasCustomer,
+  });
 
   if (ACTIVATION_EVENTS.has(type)) {
     const ensured = await ensureBeneficiaryByCPF(basePayload);
     if (ensured?.uuid) {
       try {
-        await reactivateBeneficiary(ensured.uuid);
+        await reactivateBeneficiary(ensured.uuid, basePayload);
       } catch (error) {
         console.error('[asaas/webhook] reactivate failed', ensured.uuid, error);
       }

--- a/src/app/api/checkout/finalizar/route.ts
+++ b/src/app/api/checkout/finalizar/route.ts
@@ -1,11 +1,10 @@
-﻿import axios from 'axios';
+import axios from 'axios';
 import { NextRequest, NextResponse } from 'next/server';
 import { asaas } from '@/lib/asaas';
 import { db } from '@/lib/firebaseAdmin';
-import {
-  ensureBeneficiaryByCPF,
-  reactivateBeneficiary,
-} from '@/lib/rapidocService';
+import { getAsaasCustomer } from '@/lib/asaasService';
+import { buildBeneficiaryPayload, type BeneficiaryUserRecord } from '@/lib/beneficiaryPayload';
+import { ensureBeneficiaryByCPF, reactivateBeneficiary } from '@/lib/rapidocService';
 import {
   type FinalizeRequestBody,
   type FinalizeResponseBody,
@@ -26,6 +25,7 @@ export async function POST(request: NextRequest) {
     const paymentResponse = await asaas.get(`/payments/${paymentId}`);
     const payment = paymentResponse.data as AsaasPayment;
     const status = payment.status;
+    const customerId = payment.customer;
 
     if (!PAYMENT_SUCCESS_STATUSES.includes(status as (typeof PAYMENT_SUCCESS_STATUSES)[number])) {
       return NextResponse.json<FinalizeResponseBody>(
@@ -37,39 +37,114 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    let asaasCustomer: Awaited<ReturnType<typeof getAsaasCustomer>> | null = null;
+
+    if (customerId) {
+      try {
+        asaasCustomer = await getAsaasCustomer(customerId);
+      } catch (error) {
+        console.error('[checkout/finalizar] failed to load asaas customer', customerId, error);
+      }
+    }
+
     const snapshot = await db.collection('users').where('cpf', '==', cpfDigits).limit(1).get();
 
     let userRef = snapshot.empty ? null : snapshot.docs[0].ref;
+    let user = snapshot.empty ? null : (snapshot.docs[0].data() as Record<string, any>);
 
     if (!userRef) {
-      const created = await db.collection('users').add({
-        name: payment.customer ?? 'Cliente Asaas',
+      const createdPayload: Record<string, unknown> = {
+        name: asaasCustomer?.name ?? payment.customer ?? 'Cliente Asaas',
         cpf: cpfDigits,
-        email: null,
-        phone: null,
-        zipCode: null,
-        address: null,
-        city: null,
-        state: null,
-        asaasCustomerId: payment.customer ?? null,
+        email: asaasCustomer?.email ?? null,
+        phone: asaasCustomer?.mobilePhone ?? null,
+        zipCode: asaasCustomer?.postalCode ?? null,
+        address: asaasCustomer?.address ?? null,
+        city: asaasCustomer?.city ?? asaasCustomer?.cityName ?? null,
+        state: asaasCustomer?.state ?? null,
+        birthday: null,
+        paymentType: null,
+        serviceType: null,
+        holder: asaasCustomer?.cpfCnpj ?? null,
+        general: null,
+        asaasCustomerId: customerId ?? null,
         status: 'pending',
         beneficiaryUuid: null,
         createdAt: new Date(),
         updatedAt: new Date(),
-      });
+      };
+
+      const created = await db.collection('users').add(createdPayload);
       userRef = created;
+      user = createdPayload as Record<string, any>;
     }
 
-    const ensured = await ensureBeneficiaryByCPF({
-      name: payment.customer ?? 'Cliente Asaas',
+    if (!userRef) {
+      return NextResponse.json(
+        { error: 'Usuário não encontrado para sincronizar com a Rapidoc.' },
+        { status: 404 },
+      );
+    }
+
+    const updates: Record<string, unknown> = {};
+
+    if (customerId && (!user?.asaasCustomerId || user.asaasCustomerId !== customerId)) {
+      updates.asaasCustomerId = customerId;
+    }
+
+    const assignIfMissing = (key: string, value: unknown) => {
+      if (value == null || value === '') {
+        return;
+      }
+
+      if (!user || user[key] == null || user[key] === '') {
+        updates[key] = value;
+      }
+    };
+
+    if (asaasCustomer) {
+      assignIfMissing('name', asaasCustomer.name);
+      assignIfMissing('email', asaasCustomer.email ?? null);
+      assignIfMissing('phone', asaasCustomer.mobilePhone ?? null);
+      assignIfMissing('zipCode', asaasCustomer.postalCode ?? null);
+      assignIfMissing('address', asaasCustomer.address ?? null);
+      assignIfMissing('city', asaasCustomer.city ?? asaasCustomer.cityName ?? null);
+      assignIfMissing('state', asaasCustomer.state ?? null);
+      assignIfMissing('holder', asaasCustomer.cpfCnpj ?? null);
+    }
+
+    if (Object.keys(updates).length > 0) {
+      updates.updatedAt = new Date();
+      await userRef.update(updates);
+      user = { ...(user ?? {}), ...updates } as Record<string, any>;
+    }
+
+    const ensurePayload = buildBeneficiaryPayload({
       cpf: cpfDigits,
+      user: user as BeneficiaryUserRecord | null,
+      customer: asaasCustomer,
     });
+    const ensured = await ensureBeneficiaryByCPF(ensurePayload);
 
     if (ensured?.uuid) {
       try {
-        await reactivateBeneficiary(ensured.uuid);
+        await reactivateBeneficiary(ensured.uuid, ensurePayload);
       } catch (error) {
+        if (axios.isAxiosError(error)) {
+          const statusCode = error.response?.status ?? 502;
+          const backend = error.response?.data ?? null;
+          console.error('[checkout/finalizar] reactivate failed', ensured.uuid, statusCode, backend);
+          return NextResponse.json(
+            { error: 'Failed to reactivate beneficiary', backend },
+            { status: statusCode },
+          );
+        }
+
         console.error('[checkout/finalizar] reactivate failed', ensured.uuid, error);
+        return NextResponse.json(
+          { error: 'Failed to reactivate beneficiary' },
+          { status: 500 },
+        );
       }
 
       await userRef.update({

--- a/src/app/api/checkout/pagar/route.ts
+++ b/src/app/api/checkout/pagar/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { asaas } from '@/lib/asaas';
 import { db } from '@/lib/firebaseAdmin';
+import { digitsOnly } from '@/lib/beneficiaryPayload';
 import {
   type AsaasPayment,
   type AsaasPixQrCode,
@@ -25,6 +26,16 @@ const formatDate = (value?: string) => {
 };
 
 async function resolveCustomer(body: CheckoutRequestBody, cpfDigits: string) {
+  const normalizedBirthday = body.birthday?.trim() || null;
+  const paymentTypeFromRequest = body.paymentType?.trim().toUpperCase();
+  const serviceTypeFromRequest = body.serviceType?.trim().toUpperCase();
+  const normalizedPaymentType = paymentTypeFromRequest || 'S';
+  const normalizedServiceType = serviceTypeFromRequest || 'GS';
+  const normalizedHolder = digitsOnly(body.holder) || null;
+  const normalizedGeneral = body.general?.trim() || null;
+  const normalizedPhone = body.mobilePhone ? digitsOnly(body.mobilePhone) || body.mobilePhone : null;
+  const normalizedZip = body.zipCode ? digitsOnly(body.zipCode) || body.zipCode : null;
+
   const snapshot = await db.collection('users').where('cpf', '==', cpfDigits).limit(1).get();
 
   if (!snapshot.empty) {
@@ -32,19 +43,66 @@ async function resolveCustomer(body: CheckoutRequestBody, cpfDigits: string) {
     const data = doc.data();
     let customerId: string | undefined = data.asaasCustomerId;
 
+    const updates: Record<string, unknown> = {};
+
     if (!customerId) {
       const { data: createdCustomer } = await asaas.post('/customers', {
         name: body.name,
         cpfCnpj: cpfDigits,
         email: body.email,
-        mobilePhone: body.mobilePhone,
-        postalCode: body.zipCode,
+        mobilePhone: normalizedPhone ?? body.mobilePhone,
+        postalCode: normalizedZip ?? body.zipCode,
         address: body.address,
         city: body.city,
         state: body.state,
       });
       customerId = createdCustomer.id;
       await doc.ref.update({ asaasCustomerId: customerId, updatedAt: new Date() });
+    }
+
+    const assignIfChanged = (key: string, value: unknown) => {
+      if (value == null || value === '') {
+        return;
+      }
+
+      if (data[key] !== value) {
+        updates[key] = value;
+      }
+    };
+
+    assignIfChanged('name', body.name);
+    assignIfChanged('email', body.email ?? null);
+    assignIfChanged('phone', normalizedPhone ?? null);
+    assignIfChanged('zipCode', normalizedZip ?? null);
+    assignIfChanged('address', body.address ?? null);
+    assignIfChanged('city', body.city ?? null);
+    assignIfChanged('state', body.state ?? null);
+    assignIfChanged('birthday', normalizedBirthday);
+
+    if (paymentTypeFromRequest) {
+      assignIfChanged('paymentType', normalizedPaymentType);
+    }
+
+    if (serviceTypeFromRequest) {
+      assignIfChanged('serviceType', normalizedServiceType);
+    }
+
+    if (normalizedHolder) {
+      assignIfChanged('holder', normalizedHolder);
+    } else if (!data.holder) {
+      const fallbackHolder = digitsOnly(body.cpf);
+      if (fallbackHolder) {
+        assignIfChanged('holder', fallbackHolder);
+      }
+    }
+
+    if (normalizedGeneral) {
+      assignIfChanged('general', normalizedGeneral);
+    }
+
+    if (Object.keys(updates).length > 0) {
+      updates.updatedAt = new Date();
+      await doc.ref.update(updates);
     }
 
     return { customerId: customerId!, userRef: doc.ref };
@@ -54,8 +112,8 @@ async function resolveCustomer(body: CheckoutRequestBody, cpfDigits: string) {
     name: body.name,
     cpfCnpj: cpfDigits,
     email: body.email,
-    mobilePhone: body.mobilePhone,
-    postalCode: body.zipCode,
+    mobilePhone: normalizedPhone ?? body.mobilePhone,
+    postalCode: normalizedZip ?? body.zipCode,
     address: body.address,
     city: body.city,
     state: body.state,
@@ -65,11 +123,16 @@ async function resolveCustomer(body: CheckoutRequestBody, cpfDigits: string) {
     name: body.name,
     cpf: cpfDigits,
     email: body.email || null,
-    phone: body.mobilePhone || null,
-    zipCode: body.zipCode || null,
+    phone: normalizedPhone || null,
+    zipCode: normalizedZip || null,
     address: body.address || null,
     city: body.city || null,
     state: body.state || null,
+    birthday: normalizedBirthday,
+    paymentType: normalizedPaymentType,
+    serviceType: normalizedServiceType,
+    holder: normalizedHolder || digitsOnly(body.cpf) || null,
+    general: normalizedGeneral,
     asaasCustomerId: createdCustomer.id,
     status: 'pending',
     beneficiaryUuid: null,

--- a/src/app/api/rapidoc/beneficiaries/[beneficiaryId]/reactivate/route.ts
+++ b/src/app/api/rapidoc/beneficiaries/[beneficiaryId]/reactivate/route.ts
@@ -1,8 +1,17 @@
 import { NextResponse } from 'next/server';
 import rapidoc from '@/lib/rapidoc';
 
+export async function PUT(request: Request, { params }: { params: { beneficiaryId: string } }) {
+  let payload: unknown = {};
 
-export async function PUT(_: Request, { params }: { params: { beneficiaryId: string } }) {
-const { data } = await rapidoc.put(`/beneficiaries/${params.beneficiaryId}/reactivate`, {});
-return NextResponse.json(data);
+  try {
+    const rawBody = await request.text();
+    payload = rawBody ? JSON.parse(rawBody) : {};
+  } catch (error) {
+    console.error('[rapidoc/reactivate] Failed to parse body', error);
+    payload = {};
+  }
+
+  const { data } = await rapidoc.put(`/beneficiaries/${params.beneficiaryId}/reactivate`, payload);
+  return NextResponse.json(data);
 }

--- a/src/lib/beneficiaryPayload.ts
+++ b/src/lib/beneficiaryPayload.ts
@@ -1,0 +1,89 @@
+import type { getAsaasCustomer } from '@/lib/asaasService';
+import type { BeneficiaryInput } from '@/lib/rapidocService';
+
+export type BeneficiaryUserRecord = {
+  name?: string | null;
+  cpf?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  zipCode?: string | null;
+  address?: string | null;
+  city?: string | null;
+  state?: string | null;
+  birthday?: string | null;
+  paymentType?: string | null;
+  serviceType?: string | null;
+  holder?: string | null;
+  general?: string | null;
+};
+
+export const digitsOnly = (value?: string | null) => {
+  if (!value) {
+    return undefined;
+  }
+
+  const numeric = String(value).replace(/\D/g, '');
+  return numeric || undefined;
+};
+
+type AsaasCustomer = Awaited<ReturnType<typeof getAsaasCustomer>>;
+
+type BuildPayloadArgs = {
+  cpf: string;
+  user?: BeneficiaryUserRecord | null;
+  customer?: AsaasCustomer | null;
+};
+
+export const buildBeneficiaryPayload = ({
+  cpf,
+  user,
+  customer,
+}: BuildPayloadArgs): BeneficiaryInput => {
+  const cpfDigits = digitsOnly(cpf) ?? cpf;
+
+  const payload: BeneficiaryInput = {
+    name: user?.name ?? customer?.name ?? 'Cliente Asaas',
+    cpf: cpfDigits,
+    paymentType: user?.paymentType ?? 'S',
+    serviceType: user?.serviceType ?? 'GS',
+    holder: digitsOnly(user?.holder ?? customer?.cpfCnpj ?? cpfDigits) ?? cpfDigits,
+    general: user?.general ?? 'General purpose',
+  };
+
+  const email = user?.email ?? customer?.email ?? undefined;
+  if (email) {
+    payload.email = email;
+  }
+
+  const phone = digitsOnly(user?.phone ?? customer?.mobilePhone ?? null);
+  if (phone) {
+    payload.phone = phone;
+  }
+
+  const zipCode = digitsOnly(user?.zipCode ?? customer?.postalCode ?? null);
+  if (zipCode) {
+    payload.zipCode = zipCode;
+  }
+
+  const address = user?.address ?? customer?.address ?? undefined;
+  if (address) {
+    payload.address = address;
+  }
+
+  const city = user?.city ?? customer?.city ?? customer?.cityName ?? undefined;
+  if (city) {
+    payload.city = city;
+  }
+
+  const state = user?.state ?? customer?.state ?? undefined;
+  if (state) {
+    payload.state = state;
+  }
+
+  const birthday = user?.birthday ?? undefined;
+  if (birthday) {
+    payload.birthday = birthday;
+  }
+
+  return payload;
+};

--- a/src/lib/beneficiaryPayload.ts
+++ b/src/lib/beneficiaryPayload.ts
@@ -40,14 +40,18 @@ export const buildBeneficiaryPayload = ({
   customer,
 }: BuildPayloadArgs): BeneficiaryInput => {
   const cpfDigits = digitsOnly(cpf) ?? cpf;
+  const normalizeUpper = (value?: string | null) => {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed.toUpperCase() : undefined;
+  };
 
   const payload: BeneficiaryInput = {
     name: user?.name ?? customer?.name ?? 'Cliente Asaas',
     cpf: cpfDigits,
-    paymentType: user?.paymentType ?? 'S',
-    serviceType: user?.serviceType ?? 'GS',
+    paymentType: normalizeUpper(user?.paymentType) ?? 'S',
+    serviceType: normalizeUpper(user?.serviceType) ?? 'GS',
     holder: digitsOnly(user?.holder ?? customer?.cpfCnpj ?? cpfDigits) ?? cpfDigits,
-    general: user?.general ?? 'General purpose',
+    general: user?.general?.trim() || 'General purpose',
   };
 
   const email = user?.email ?? customer?.email ?? undefined;
@@ -80,7 +84,7 @@ export const buildBeneficiaryPayload = ({
     payload.state = state;
   }
 
-  const birthday = user?.birthday ?? undefined;
+  const birthday = user?.birthday?.trim() ?? undefined;
   if (birthday) {
     payload.birthday = birthday;
   }

--- a/src/lib/rapidocService.ts
+++ b/src/lib/rapidocService.ts
@@ -10,6 +10,10 @@ export type BeneficiaryInput = {
   address?: string;
   city?: string;
   state?: string;
+  paymentType?: string;
+  serviceType?: string;
+  holder?: string;
+  general?: string;
 };
 
 export async function getBeneficiaryByCPF(cpf: string) {
@@ -24,8 +28,11 @@ export async function createBeneficiaryOne(payload: BeneficiaryInput) {
   return { raw: data, uuid };
 }
 
-export async function reactivateBeneficiary(beneficiaryId: string) {
-  const response = await rapidoc.put(`/beneficiaries/${beneficiaryId}/reactivate`, {});
+export async function reactivateBeneficiary(
+  beneficiaryId: string,
+  payload: BeneficiaryInput,
+) {
+  const response = await rapidoc.put(`/beneficiaries/${beneficiaryId}/reactivate`, payload);
   return response.data;
 }
 

--- a/src/types/checkout.ts
+++ b/src/types/checkout.ts
@@ -14,6 +14,11 @@ export type CheckoutRequestBody = {
   address?: string;
   city?: string;
   state?: string;
+  birthday?: string;
+  paymentType?: string;
+  serviceType?: string;
+  holder?: string;
+  general?: string;
   creditCard?: {
     holderName: string;
     number: string;


### PR DESCRIPTION
## Summary
- add a reusable helper to build complete Rapidoc beneficiary payloads from user and Asaas data
- send the enriched payload when reactivating beneficiaries during manual finalize and webhook flows to avoid missing-field errors
- allow the internal Rapidoc reactivation endpoint and client to forward the payload required by the Rapidoc API

## Testing
- npm run build *(fails: Next.js could not download Google Fonts in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e33ef4fb8883289e017ae1a10b7351