### PR TITLE
Implement idempotent checkout finalize and Rapidoc ensure flow

### DIFF
--- a/src/app/(public)/assinante/pagar/page.tsx
+++ b/src/app/(public)/assinante/pagar/page.tsx
@@ -1,4 +1,13 @@
-﻿'use client';
+/**
+ * Testes (Postman):
+ * 1. Criar pagamento no Asaas e obter o paymentId.
+ * 2. Confirmar pagamento no sandbox (RECEIVED/CONFIRMED).
+ * 3. GET /api/checkout/status/{paymentId} para acompanhar.
+ * 4. POST /api/checkout/finalizar com { paymentId, cpf } pelo botão.
+ * 5. GET /api/rapidoc/beneficiaries/cpf/{cpf} confirma o beneficiário.
+ */
+
+'use client';
 
 import axios from 'axios';
 import { useEffect, useMemo, useState } from 'react';
@@ -71,24 +80,33 @@ const getDefaultDueDate = () => {
   return formatDateInput(date.toISOString());
 };
 
+const asRecord = (value: unknown) => (typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null);
+const asString = (value: unknown) => (typeof value === 'string' ? value : undefined);
+const firstRecord = (value: unknown) =>
+  Array.isArray(value) && value.length > 0 && typeof value[0] === 'object' && value[0] !== null
+    ? (value[0] as Record<string, unknown>)
+    : null;
+
 const extractErrorMessage = (error: unknown): string => {
   if (!axios.isAxiosError(error)) {
     return error instanceof Error ? error.message : 'Erro inesperado';
   }
 
-  const data = error.response?.data as any;
+  const data = asRecord(error.response?.data);
+  const hint = asString(data?.hint);
+  const errorsRecord = firstRecord(data?.errors);
+  const nestedError = asRecord(data?.error);
+  const nestedErrorsRecord = firstRecord(nestedError?.errors);
   const description =
-    data?.errors?.[0]?.description ||
-    data?.error?.errors?.[0]?.description ||
-    data?.error?.message ||
-    data?.error?.description ||
-    data?.error;
+    asString(data?.message) ||
+    asString(errorsRecord?.description) ||
+    asString(nestedErrorsRecord?.description) ||
+    asString(nestedError?.message) ||
+    asString(nestedError?.description) ||
+    asString(data?.error);
 
-  if (typeof description === 'string') {
-    return description;
-  }
-
-  return error.message ?? 'Erro ao processar requisição';
+  const message = typeof description === 'string' ? description : error.message ?? 'Erro ao processar requisição';
+  return hint ? `${hint}: ${message}` : message;
 };
 
 const PAYMENT_TYPE_OPTIONS = [
@@ -405,6 +423,7 @@ export default function PagarPage() {
 
     setError('');
     setSuccess('');
+    setInfoMessage('');
     setFinalizing(true);
 
     try {
@@ -414,17 +433,33 @@ export default function PagarPage() {
       });
 
       if (data.ok) {
-        setSuccess('Beneficiário ativo com sucesso!');
-        setInfoMessage('Rapidoc sincronizado.');
-        setStatus(data.status);
+        const created = Boolean(data.ensured?.created);
+        const uuid = data.ensured?.uuid ?? 'desconhecido';
+        setSuccess(
+          created
+            ? `Beneficiário criado e ativado com sucesso (uuid: ${uuid}).`
+            : `Beneficiário confirmado e reativado (uuid: ${uuid}).`,
+        );
+        setInfoMessage(created ? 'Rapidoc criou um novo registro.' : 'Beneficiário existente reativado.');
+        if (data.status) {
+          setStatus(data.status);
+        }
+        setRawLog(data);
         if (typeof window !== 'undefined') {
           window.localStorage.removeItem(STORAGE_KEY);
         }
       } else {
-        setError('Pagamento ainda não confirmado.');
+        setError(`payment_not_confirmed: Pagamento ainda não confirmado (status: ${data.status ?? 'desconhecido'}).`);
       }
     } catch (err) {
-      setError(extractErrorMessage(err));
+      const message = extractErrorMessage(err);
+      setError(message);
+      if (axios.isAxiosError(err)) {
+        const hint = err.response?.data?.hint as string | undefined;
+        if (hint) {
+          setInfoMessage(`Hint recebido: ${hint}`);
+        }
+      }
     } finally {
       setFinalizing(false);
     }

--- a/src/app/api/checkout/finalizar/route.ts
+++ b/src/app/api/checkout/finalizar/route.ts
@@ -1,240 +1,320 @@
+/**
+ * Testes (Postman):
+ * 1. Criar pagamento no Asaas e obter o paymentId.
+ * 2. Confirmar pagamento no sandbox e aguardar status RECEIVED/CONFIRMED.
+ * 3. GET /api/checkout/status/{paymentId} para validar o status.
+ * 4. POST /api/checkout/finalizar com { paymentId, cpf } e verificar ensured.uuid.
+ * 5. GET /api/rapidoc/beneficiaries/cpf/{cpf} para confirmar o beneficiário ativo.
+ */
+
 import axios from 'axios';
 import { NextRequest, NextResponse } from 'next/server';
 import { asaas } from '@/lib/asaas';
 import { db } from '@/lib/firebaseAdmin';
 import { getAsaasCustomer } from '@/lib/asaasService';
 import { buildBeneficiaryPayload, type BeneficiaryUserRecord } from '@/lib/beneficiaryPayload';
-import { ensureBeneficiaryByCPF, reactivateBeneficiary } from '@/lib/rapidocService';
 import {
+  ensureBeneficiaryByCPF,
+  reactivateBeneficiary,
+  sanitizeCPF,
+} from '@/lib/rapidocService';
+import {
+  type AsaasPayment,
   type FinalizeRequestBody,
   type FinalizeResponseBody,
   PAYMENT_SUCCESS_STATUSES,
-  type AsaasPayment,
 } from '@/types/checkout';
 
-const digitsOnly = (value?: string | null) => {
-  if (!value) {
-    return undefined;
+const SUCCESS_STATUS = new Set(PAYMENT_SUCCESS_STATUSES);
+
+const jsonError = (
+  hint: string,
+  status: number,
+  message: string,
+  upstream: unknown = null,
+) =>
+  NextResponse.json(
+    {
+      hint,
+      upstreamStatus: status,
+      message,
+      upstream: typeof upstream === 'string' ? upstream : upstream ?? null,
+    },
+    { status },
+  );
+
+const handleUpstreamError = (error: unknown, hint: string) => {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status && error.response.status !== 200 ? error.response.status : 500;
+    const upstreamStatus = error.response?.status ?? 500;
+    const upstreamData = error.response?.data;
+    const upstreamObject =
+      typeof upstreamData === 'object' && upstreamData !== null
+        ? (upstreamData as Record<string, unknown>)
+        : null;
+    const upstreamError =
+      upstreamObject && typeof upstreamObject.error === 'object' && upstreamObject.error !== null
+        ? (upstreamObject.error as Record<string, unknown>)
+        : null;
+    const message =
+      (upstreamObject?.message as string | undefined) ||
+      (upstreamError?.message as string | undefined) ||
+      error.message ||
+      'unknown error';
+
+    return NextResponse.json(
+      {
+        hint,
+        upstreamStatus,
+        message,
+        upstream: typeof upstreamData === 'string' ? upstreamData : upstreamData ?? null,
+      },
+      { status },
+    );
   }
 
-  const numeric = String(value).replace(/\D/g, '');
-  return numeric || undefined;
+  const message = error instanceof Error ? error.message : 'unknown error';
+  return jsonError(hint, 500, message);
 };
 
-const resolveEnsurePayload = (
-  cpfDigits: string,
-  user: Record<string, any> | null,
-  customer: Awaited<ReturnType<typeof getAsaasCustomer>> | null,
-): BeneficiaryInput => {
-  const payload: BeneficiaryInput = {
-    name: user?.name ?? customer?.name ?? 'Cliente Asaas',
-    cpf: cpfDigits,
-    paymentType: user?.paymentType ?? 'S',
-    serviceType: user?.serviceType ?? 'GS',
-    holder: digitsOnly(user?.holder ?? customer?.cpfCnpj ?? cpfDigits) ?? cpfDigits,
-    general: user?.general ?? 'General purpose',
-  };
-
-  const email = user?.email ?? customer?.email ?? undefined;
-  if (email) {
-    payload.email = email;
+const assignIfMissing = (
+  target: Record<string, unknown>,
+  existing: Record<string, unknown> | null,
+  key: string,
+  value: unknown,
+) => {
+  if (value == null || value === '') {
+    return;
   }
 
-  const phone = digitsOnly(user?.phone ?? customer?.mobilePhone ?? null);
-  if (phone) {
-    payload.phone = phone;
+  if (!existing || existing[key] == null || existing[key] === '') {
+    target[key] = value;
   }
+};
 
-  const zipCode = digitsOnly(user?.zipCode ?? customer?.postalCode ?? null);
-  if (zipCode) {
-    payload.zipCode = zipCode;
+type HintedError = { hint?: string; status?: number };
+const isHintedError = (value: unknown): value is HintedError =>
+  typeof value === 'object' && value !== null && 'hint' in value;
+
+const fetchPayment = async (paymentId: string) => {
+  const started = Date.now();
+  console.info(`[checkout/finalizar] fetching payment ${paymentId}`);
+  const response = await asaas.get(`/payments/${paymentId}`);
+  console.info(
+    `[checkout/finalizar] payment ${paymentId} loaded status=${response.data?.status ?? 'unknown'} ms=${Date.now() - started}`,
+  );
+  return response.data as AsaasPayment;
+};
+
+const loadAsaasCustomer = async (customerId: string) => {
+  try {
+    const started = Date.now();
+    console.info(`[checkout/finalizar] fetching customer ${customerId}`);
+    const customer = await getAsaasCustomer(customerId);
+    console.info(
+      `[checkout/finalizar] customer ${customerId} loaded ms=${Date.now() - started}`,
+    );
+    return customer;
+  } catch (error) {
+    console.error('[checkout/finalizar] failed to fetch customer', customerId, error);
+    return null;
   }
-
-  const address = user?.address ?? customer?.address ?? undefined;
-  if (address) {
-    payload.address = address;
-  }
-
-  const city = user?.city ?? customer?.city ?? customer?.cityName ?? undefined;
-  if (city) {
-    payload.city = city;
-  }
-
-  const state = user?.state ?? customer?.state ?? undefined;
-  if (state) {
-    payload.state = state;
-  }
-
-  const birthday = user?.birthday ?? undefined;
-  if (birthday) {
-    payload.birthday = birthday;
-  }
-
-  return payload;
 };
 
 export async function POST(request: NextRequest) {
+  const started = Date.now();
+  console.info('[checkout/finalizar] received request');
+
+  let body: FinalizeRequestBody = {};
   try {
-    const body = (await request.json()) as FinalizeRequestBody;
-    const cpfDigits = (body.cpf || '').replace(/\D/g, '');
-    const paymentId = body.paymentId?.trim();
+    body = ((await request.json()) ?? {}) as FinalizeRequestBody;
+  } catch (error) {
+    console.warn('[checkout/finalizar] body parse failed, assuming empty', error);
+    body = {};
+  }
 
-    if (!cpfDigits || !paymentId) {
-      return NextResponse.json({ error: 'cpf and paymentId are required' }, { status: 400 });
+  const paymentId = body.paymentId?.trim();
+  const providedCpf = body.cpf ? sanitizeCPF(body.cpf) : undefined;
+
+  if (providedCpf && providedCpf.length !== 11) {
+    return jsonError('cpf_invalid', 400, 'CPF deve conter 11 dígitos.', { cpf: providedCpf });
+  }
+
+  let payment: AsaasPayment | null = null;
+  let paymentStatus: string | undefined;
+  let customerId: string | undefined;
+
+  if (paymentId) {
+    try {
+      payment = await fetchPayment(paymentId);
+      paymentStatus = payment.status;
+      customerId = typeof payment.customer === 'string' ? payment.customer : undefined;
+
+      if (paymentStatus && !SUCCESS_STATUS.has(paymentStatus as (typeof PAYMENT_SUCCESS_STATUSES)[number])) {
+        return jsonError('payment_not_confirmed', 409, 'Pagamento ainda não confirmado.', {
+          status: paymentStatus,
+        });
+      }
+    } catch (error) {
+      console.error('[checkout/finalizar] error loading payment', paymentId, error);
+      return handleUpstreamError(error, 'asaas-payment');
     }
+  }
 
-    const paymentResponse = await asaas.get(`/payments/${paymentId}`);
-    const payment = paymentResponse.data as AsaasPayment;
-    const status = payment.status;
-    const customerId = payment.customer;
+  let cpfDigits = providedCpf;
+  let asaasCustomer: Awaited<ReturnType<typeof getAsaasCustomer>> | null = null;
 
-    if (!PAYMENT_SUCCESS_STATUSES.includes(status as (typeof PAYMENT_SUCCESS_STATUSES)[number])) {
-      return NextResponse.json<FinalizeResponseBody>(
-        {
-          ok: false,
-          status,
-        },
-        { status: 409 },
-      );
+  if (!cpfDigits && payment && customerId) {
+    asaasCustomer = await loadAsaasCustomer(customerId);
+    cpfDigits = sanitizeCPF(asaasCustomer?.cpfCnpj ?? '');
+  }
+
+  if (!cpfDigits && payment && typeof payment.cpfCnpj === 'string') {
+    cpfDigits = sanitizeCPF(payment.cpfCnpj);
+  }
+
+  if (!cpfDigits && customerId && !asaasCustomer) {
+    asaasCustomer = await loadAsaasCustomer(customerId);
+    cpfDigits = sanitizeCPF(asaasCustomer?.cpfCnpj ?? '');
+  }
+
+  if (!cpfDigits || cpfDigits.length !== 11) {
+    return jsonError('missing_cpf_source', 400, 'Não foi possível identificar o CPF do pagador.');
+  }
+
+  if (!asaasCustomer && customerId) {
+    asaasCustomer = await loadAsaasCustomer(customerId);
+  }
+
+  const paymentDocRef = paymentId ? db.collection('payments').doc(paymentId) : null;
+  if (paymentDocRef) {
+    try {
+      const existingDoc = await paymentDocRef.get();
+      if (existingDoc.exists) {
+        const data = existingDoc.data() ?? {};
+        if (data.processed) {
+          console.info(`[checkout/finalizar] idempotent hit payment=${paymentId}`);
+          return NextResponse.json<FinalizeResponseBody>({
+            ok: true,
+            status: (data.status as string) ?? paymentStatus ?? 'CONFIRMED',
+            ensured: data.beneficiaryUuid
+              ? { uuid: data.beneficiaryUuid as string, created: Boolean(data.beneficiaryCreated) }
+              : null,
+          });
+        }
+      }
+    } catch (error) {
+      console.error('[checkout/finalizar] failed to load payment doc', paymentId, error);
     }
+  }
 
-    let asaasCustomer: Awaited<ReturnType<typeof getAsaasCustomer>> | null = null;
+  const usersCollection = db.collection('users');
+  let userSnapshot = await usersCollection.where('cpf', '==', cpfDigits).limit(1).get();
+  if (userSnapshot.empty && customerId) {
+    userSnapshot = await usersCollection.where('asaasCustomerId', '==', customerId).limit(1).get();
+  }
+
+  let userRef = userSnapshot.empty ? null : userSnapshot.docs[0].ref;
+  let userData = userSnapshot.empty ? null : (userSnapshot.docs[0].data() as Record<string, unknown>);
+
+  if (!userRef) {
+    const createdPayload: Record<string, unknown> = {
+      cpf: cpfDigits,
+      asaasCustomerId: customerId ?? null,
+      status: 'pending',
+      beneficiaryUuid: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const created = await usersCollection.add(createdPayload);
+    userRef = created;
+    userData = createdPayload;
+  }
+
+  const ensurePayload = buildBeneficiaryPayload({
+    cpf: cpfDigits,
+    user: (userData as BeneficiaryUserRecord | null) ?? null,
+    customer: asaasCustomer,
+  });
+
+  let ensured;
+  try {
+    ensured = await ensureBeneficiaryByCPF(ensurePayload);
+  } catch (error) {
+    console.error('[checkout/finalizar] ensure beneficiary failed', cpfDigits, error);
+    if (isHintedError(error)) {
+      return jsonError(error.hint ?? 'rapidoc-error', error.status ?? 500, 'Não foi possível garantir o beneficiário.', error);
+    }
+    return handleUpstreamError(error, 'rapidoc-ensure');
+  }
+
+  if (!ensured?.uuid) {
+    return jsonError('rapidoc-ensure', 500, 'Beneficiário sem identificador retornado.');
+  }
+
+  try {
+    await reactivateBeneficiary(ensured.uuid);
+  } catch (error) {
+    if (axios.isAxiosError(error) && [409, 422].includes(error.response?.status ?? 0)) {
+      console.info('[checkout/finalizar] reactivate ignored status', error.response?.status);
+    } else {
+      console.error('[checkout/finalizar] reactivate failed', ensured.uuid, error);
+      return handleUpstreamError(error, 'rapidoc-reactivate');
+    }
+  }
+
+  if (userRef) {
+    const updates: Record<string, unknown> = {
+      status: 'active',
+      beneficiaryUuid: ensured.uuid,
+      updatedAt: new Date(),
+    };
 
     if (customerId) {
-      try {
-        asaasCustomer = await getAsaasCustomer(customerId);
-      } catch (error) {
-        console.error('[checkout/finalizar] failed to load asaas customer', customerId, error);
-      }
-    }
-
-    const snapshot = await db.collection('users').where('cpf', '==', cpfDigits).limit(1).get();
-
-    let userRef = snapshot.empty ? null : snapshot.docs[0].ref;
-    let user = snapshot.empty ? null : (snapshot.docs[0].data() as Record<string, any>);
-
-    if (!userRef) {
-      const createdPayload: Record<string, unknown> = {
-        name: asaasCustomer?.name ?? payment.customer ?? 'Cliente Asaas',
-        cpf: cpfDigits,
-        email: asaasCustomer?.email ?? null,
-        phone: asaasCustomer?.mobilePhone ?? null,
-        zipCode: asaasCustomer?.postalCode ?? null,
-        address: asaasCustomer?.address ?? null,
-        city: asaasCustomer?.city ?? asaasCustomer?.cityName ?? null,
-        state: asaasCustomer?.state ?? null,
-        birthday: null,
-        paymentType: null,
-        serviceType: null,
-        holder: asaasCustomer?.cpfCnpj ?? null,
-        general: null,
-        asaasCustomerId: customerId ?? null,
-        status: 'pending',
-        beneficiaryUuid: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-
-      const created = await db.collection('users').add(createdPayload);
-      userRef = created;
-      user = createdPayload as Record<string, any>;
-    }
-
-    if (!userRef) {
-      return NextResponse.json(
-        { error: 'Usuário não encontrado para sincronizar com a Rapidoc.' },
-        { status: 404 },
-      );
-    }
-
-    const updates: Record<string, unknown> = {};
-
-    if (customerId && (!user?.asaasCustomerId || user.asaasCustomerId !== customerId)) {
       updates.asaasCustomerId = customerId;
     }
 
-    const assignIfMissing = (key: string, value: unknown) => {
-      if (value == null || value === '') {
-        return;
-      }
-
-      if (!user || user[key] == null || user[key] === '') {
-        updates[key] = value;
-      }
-    };
+    if (paymentId) {
+      updates.lastPaymentId = paymentId;
+    }
 
     if (asaasCustomer) {
-      assignIfMissing('name', asaasCustomer.name);
-      assignIfMissing('email', asaasCustomer.email ?? null);
-      assignIfMissing('phone', asaasCustomer.mobilePhone ?? null);
-      assignIfMissing('zipCode', asaasCustomer.postalCode ?? null);
-      assignIfMissing('address', asaasCustomer.address ?? null);
-      assignIfMissing('city', asaasCustomer.city ?? asaasCustomer.cityName ?? null);
-      assignIfMissing('state', asaasCustomer.state ?? null);
-      assignIfMissing('holder', asaasCustomer.cpfCnpj ?? null);
+      assignIfMissing(updates, userData, 'name', asaasCustomer.name);
+      assignIfMissing(updates, userData, 'email', asaasCustomer.email ?? null);
+      assignIfMissing(updates, userData, 'phone', asaasCustomer.mobilePhone ?? null);
+      assignIfMissing(updates, userData, 'zipCode', asaasCustomer.postalCode ?? null);
+      assignIfMissing(updates, userData, 'address', asaasCustomer.address ?? null);
+      assignIfMissing(updates, userData, 'city', asaasCustomer.city ?? asaasCustomer.cityName ?? null);
+      assignIfMissing(updates, userData, 'state', asaasCustomer.state ?? null);
+      assignIfMissing(updates, userData, 'holder', asaasCustomer.cpfCnpj ?? null);
     }
 
-    if (Object.keys(updates).length > 0) {
-      updates.updatedAt = new Date();
-      await userRef.update(updates);
-      user = { ...(user ?? {}), ...updates } as Record<string, any>;
-    }
-
-    const ensurePayload = buildBeneficiaryPayload({
-      cpf: cpfDigits,
-      user: user as BeneficiaryUserRecord | null,
-      customer: asaasCustomer,
-    });
-    const ensured = await ensureBeneficiaryByCPF(ensurePayload);
-
-    if (ensured?.uuid) {
-      try {
-        await reactivateBeneficiary(ensured.uuid, ensurePayload);
-      } catch (error) {
-        if (axios.isAxiosError(error)) {
-          const statusCode = error.response?.status ?? 502;
-          const backend = error.response?.data ?? null;
-          console.error('[checkout/finalizar] reactivate failed', ensured.uuid, statusCode, backend);
-          return NextResponse.json(
-            { error: 'Failed to reactivate beneficiary', backend },
-            { status: statusCode },
-          );
-        }
-
-        console.error('[checkout/finalizar] reactivate failed', ensured.uuid, error);
-        return NextResponse.json(
-          { error: 'Failed to reactivate beneficiary' },
-          { status: 500 },
-        );
-      }
-
-      await userRef.update({
-        status: 'active',
-        beneficiaryUuid: ensured.uuid,
-        lastPaymentId: paymentId,
-        updatedAt: new Date(),
-      });
-    }
-
-    return NextResponse.json<FinalizeResponseBody>({
-      ok: true,
-      status,
-      ensured,
-    });
-  } catch (error: unknown) {
-    if (axios.isAxiosError(error)) {
-      const status = error.response?.status ?? 502;
-      const backend = error.response?.data ?? null;
-      console.error('[checkout/finalizar] asaas error', status, backend);
-      return NextResponse.json({ error: backend || 'Asaas error' }, { status });
-    }
-
-    console.error('[checkout/finalizar] unexpected error', error);
-    return NextResponse.json(
-      {
-        error: error instanceof Error ? error.message : 'Unexpected error',
-      },
-      { status: 500 },
-    );
+    await userRef.set(updates, { merge: true });
+    userData = { ...(userData ?? {}), ...updates };
   }
+
+  const resolvedStatus = paymentStatus ?? 'CONFIRMED';
+
+  if (paymentDocRef) {
+    const docPayload: Record<string, unknown> = {
+      processed: true,
+      processedAt: new Date(),
+      cpf: cpfDigits,
+      beneficiaryUuid: ensured.uuid,
+      beneficiaryCreated: Boolean(ensured.created),
+      status: resolvedStatus,
+    };
+
+    await paymentDocRef.set(docPayload, { merge: true });
+  }
+
+  console.info(
+    `[checkout/finalizar] completed in ${Date.now() - started}ms payment=${paymentId ?? 'none'} ensured=${ensured.uuid}`,
+  );
+
+  return NextResponse.json<FinalizeResponseBody>({
+    ok: true,
+    status: resolvedStatus,
+    ensured: { uuid: ensured.uuid, created: Boolean(ensured.created) },
+  });
 }

--- a/src/app/api/checkout/status/[paymentId]/route.ts
+++ b/src/app/api/checkout/status/[paymentId]/route.ts
@@ -1,24 +1,73 @@
-﻿import { NextResponse } from 'next/server';
+/**
+ * Testes (Postman):
+ * 1. Criar pagamento no Asaas e obter o paymentId.
+ * 2. Confirmar pagamento no sandbox e aguardar status RECEIVED/CONFIRMED.
+ * 3. GET /api/checkout/status/{paymentId} deve retornar status e payload bruto.
+ * 4. POST /api/checkout/finalizar com { paymentId, cpf }.
+ * 5. GET /api/rapidoc/beneficiaries/cpf/{cpf} confirma o beneficiário.
+ */
+
 import axios from 'axios';
+import { NextRequest, NextResponse } from 'next/server';
 import { asaas } from '@/lib/asaas';
 
-export async function GET(
-  _request: Request,
-  context: { params: { paymentId: string } },
-) {
-  try {
-    const { paymentId } = context.params;
-    const { data } = await asaas.get(`/payments/${paymentId}`);
-    return NextResponse.json({ status: data?.status, raw: data });
-  } catch (error: any) {
-    if (axios.isAxiosError(error)) {
-      const status = error.response?.status || 502;
-      return NextResponse.json({ error: error.response?.data || null }, { status });
-    }
+const jsonError = (hint: string, status: number, message: string, upstream: unknown = null) =>
+  NextResponse.json(
+    {
+      hint,
+      upstreamStatus: status,
+      message,
+      upstream: typeof upstream === 'string' ? upstream : upstream ?? null,
+    },
+    { status },
+  );
+
+const handleUpstreamError = (error: unknown, hint: string) => {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status && error.response.status !== 200 ? error.response.status : 500;
+    const upstreamStatus = error.response?.status ?? 500;
+    const upstreamData = error.response?.data;
+    const message =
+      (typeof upstreamData === 'object' && upstreamData !== null
+        ? ((upstreamData as Record<string, unknown>).message as string | undefined)
+        : undefined) ||
+      (typeof upstreamData === 'object' && upstreamData !== null && 'error' in upstreamData
+        ? ((upstreamData as { error?: Record<string, unknown> }).error?.message as string | undefined)
+        : undefined) ||
+      error.message ||
+      'unknown error';
 
     return NextResponse.json(
-      { error: error?.message || 'unknown error' },
-      { status: 500 },
+      {
+        hint,
+        upstreamStatus,
+        message,
+        upstream: typeof upstreamData === 'string' ? upstreamData : upstreamData ?? null,
+      },
+      { status },
     );
+  }
+
+  const message = error instanceof Error ? error.message : 'unknown error';
+  return jsonError(hint, 500, message);
+};
+
+export async function GET(_request: NextRequest, ctx: { params: Promise<{ paymentId: string }> }) {
+  const { paymentId } = await ctx.params;
+  const trimmed = paymentId?.trim();
+
+  if (!trimmed) {
+    return jsonError('paymentId_missing', 400, 'paymentId é obrigatório.');
+  }
+
+  try {
+    const started = Date.now();
+    console.info(`[checkout/status] fetching payment ${trimmed}`);
+    const { data } = await asaas.get(`/payments/${trimmed}`);
+    console.info(`[checkout/status] done payment=${trimmed} status=${data?.status ?? 'unknown'} ms=${Date.now() - started}`);
+    return NextResponse.json({ status: data?.status, raw: data });
+  } catch (error) {
+    console.error('[checkout/status] failed', trimmed, error);
+    return handleUpstreamError(error, 'asaas-payment');
   }
 }

--- a/src/app/api/rapidoc/agendamentos/[uuid]/route.ts
+++ b/src/app/api/rapidoc/agendamentos/[uuid]/route.ts
@@ -1,14 +1,87 @@
-﻿import { NextResponse } from 'next/server';
+/**
+ * Testes (Postman):
+ * 1. Criar agendamento na Rapidoc (fora do escopo).
+ * 2. GET /api/rapidoc/agendamentos/{uuid} deve retornar o agendamento.
+ * 3. DELETE /api/rapidoc/agendamentos/{uuid} remove o agendamento.
+ * 4. Validar respostas com logs.
+ * 5. Recriar o agendamento se necessário.
+ */
+
+import axios from 'axios';
+import { NextRequest, NextResponse } from 'next/server';
 import rapidoc from '@/lib/rapidoc';
 
+const jsonError = (hint: string, status: number, message: string, upstream: unknown = null) =>
+  NextResponse.json(
+    {
+      hint,
+      upstreamStatus: status,
+      message,
+      upstream: typeof upstream === 'string' ? upstream : upstream ?? null,
+    },
+    { status },
+  );
 
-export async function GET(_: Request, { params }: { params: { uuid: string } }) {
-const { data } = await rapidoc.get(`/appointments/${params.uuid}`);
-return NextResponse.json(data);
+const handleUpstreamError = (error: unknown, hint: string) => {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status && error.response.status !== 200 ? error.response.status : 500;
+    const upstreamStatus = error.response?.status ?? 500;
+    const upstreamData = error.response?.data;
+    const message =
+      (typeof upstreamData === 'object' && upstreamData !== null
+        ? ((upstreamData as Record<string, unknown>).message as string | undefined)
+        : undefined) ||
+      (typeof upstreamData === 'object' && upstreamData !== null && 'error' in upstreamData
+        ? ((upstreamData as { error?: Record<string, unknown> }).error?.message as string | undefined)
+        : undefined) ||
+      error.message ||
+      'unknown error';
+
+    return NextResponse.json(
+      {
+        hint,
+        upstreamStatus,
+        message,
+        upstream: typeof upstreamData === 'string' ? upstreamData : upstreamData ?? null,
+      },
+      { status },
+    );
+  }
+
+  const message = error instanceof Error ? error.message : 'unknown error';
+  return jsonError(hint, 500, message);
+};
+
+export async function GET(_request: NextRequest, ctx: { params: Promise<{ uuid: string }> }) {
+  const { uuid } = await ctx.params;
+  const trimmed = uuid?.trim();
+
+  if (!trimmed) {
+    return jsonError('uuid_missing', 400, 'uuid é obrigatório.');
+  }
+
+  try {
+    const { data } = await rapidoc.get(`/appointments/${trimmed}`);
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('[rapidoc/agendamentos] get failed', trimmed, error);
+    return handleUpstreamError(error, 'rapidoc-get');
+  }
 }
 
+export async function DELETE(_request: NextRequest, ctx: { params: Promise<{ uuid: string }> }) {
+  const { uuid } = await ctx.params;
+  const trimmed = uuid?.trim();
 
-export async function DELETE(_: Request, { params }: { params: { uuid: string } }) {
-const { data } = await rapidoc.delete(`/appointments/${params.uuid}`);
-return NextResponse.json(data);
+  if (!trimmed) {
+    return jsonError('uuid_missing', 400, 'uuid é obrigatório.');
+  }
+
+  try {
+    const { data } = await rapidoc.delete(`/appointments/${trimmed}`);
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('[rapidoc/agendamentos] delete failed', trimmed, error);
+    return handleUpstreamError(error, 'rapidoc-delete');
+  }
 }

--- a/src/app/api/rapidoc/beneficiaries/[beneficiaryId]/consults/route.ts
+++ b/src/app/api/rapidoc/beneficiaries/[beneficiaryId]/consults/route.ts
@@ -1,7 +1,20 @@
-import { NextResponse } from "next/server";
+/**
+ * Testes (Postman):
+ * 1. Criar beneficiário via checkout finalizado.
+ * 2. GET /api/rapidoc/beneficiaries/{beneficiaryId}/consults (placeholder) retorna mensagem.
+ * 3. Ajustar conforme necessidade futura.
+ * 4. Verificar logs para confirmar params resolvidos.
+ * 5. --
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
 
 type Params = { beneficiaryId: string };
 
-export async function GET(request: Request, context: { params: Params }) {
-  return NextResponse.json({ message: "Listar consultas nao implementado", beneficiaryId: context.params.beneficiaryId });
+export async function GET(_request: NextRequest, ctx: { params: Promise<Params> }) {
+  const { beneficiaryId } = await ctx.params;
+  return NextResponse.json({
+    message: 'Listar consultas nao implementado',
+    beneficiaryId,
+  });
 }

--- a/src/app/api/rapidoc/beneficiaries/[beneficiaryId]/inactive/route.ts
+++ b/src/app/api/rapidoc/beneficiaries/[beneficiaryId]/inactive/route.ts
@@ -1,8 +1,70 @@
-import { NextResponse } from 'next/server';
+/**
+ * Testes (Postman):
+ * 1. Criar pagamento e confirmar no Asaas.
+ * 2. Finalizar checkout para criar beneficiário.
+ * 3. DELETE /api/rapidoc/beneficiaries/{beneficiaryId}/inactive para inativar.
+ * 4. GET /api/rapidoc/beneficiaries/cpf/{cpf} confirma status.
+ * 5. PUT /api/rapidoc/beneficiaries/{beneficiaryId}/reactivate para reativar.
+ */
+
+import axios from 'axios';
+import { NextRequest, NextResponse } from 'next/server';
 import rapidoc from '@/lib/rapidoc';
 
+const jsonError = (hint: string, status: number, message: string, upstream: unknown = null) =>
+  NextResponse.json(
+    {
+      hint,
+      upstreamStatus: status,
+      message,
+      upstream: typeof upstream === 'string' ? upstream : upstream ?? null,
+    },
+    { status },
+  );
 
-export async function DELETE(_: Request, { params }: { params: { beneficiaryId: string } }) {
-const { data } = await rapidoc.delete(`/beneficiaries/${params.beneficiaryId}`);
-return NextResponse.json(data);
+const handleUpstreamError = (error: unknown, hint: string) => {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status && error.response.status !== 200 ? error.response.status : 500;
+    const upstreamStatus = error.response?.status ?? 500;
+    const upstreamData = error.response?.data;
+    const message =
+      (typeof upstreamData === 'object' && upstreamData !== null
+        ? ((upstreamData as Record<string, unknown>).message as string | undefined)
+        : undefined) ||
+      (typeof upstreamData === 'object' && upstreamData !== null && 'error' in upstreamData
+        ? ((upstreamData as { error?: Record<string, unknown> }).error?.message as string | undefined)
+        : undefined) ||
+      error.message ||
+      'unknown error';
+
+    return NextResponse.json(
+      {
+        hint,
+        upstreamStatus,
+        message,
+        upstream: typeof upstreamData === 'string' ? upstreamData : upstreamData ?? null,
+      },
+      { status },
+    );
+  }
+
+  const message = error instanceof Error ? error.message : 'unknown error';
+  return jsonError(hint, 500, message);
+};
+
+export async function DELETE(_request: NextRequest, ctx: { params: Promise<{ beneficiaryId: string }> }) {
+  const { beneficiaryId } = await ctx.params;
+  const trimmed = beneficiaryId?.trim();
+
+  if (!trimmed) {
+    return jsonError('beneficiary_missing', 400, 'beneficiaryId é obrigatório.');
+  }
+
+  try {
+    const { data } = await rapidoc.delete(`/beneficiaries/${trimmed}`);
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('[rapidoc/beneficiaries/inactive] delete failed', trimmed, error);
+    return handleUpstreamError(error, 'rapidoc-delete');
+  }
 }

--- a/src/app/api/rapidoc/beneficiaries/[beneficiaryId]/reactivate/route.ts
+++ b/src/app/api/rapidoc/beneficiaries/[beneficiaryId]/reactivate/route.ts
@@ -1,17 +1,56 @@
-import { NextResponse } from 'next/server';
-import rapidoc from '@/lib/rapidoc';
+/**
+ * Testes (Postman):
+ * 1. Criar pagamento e finalizar checkout para criar beneficiário.
+ * 2. DELETE /api/rapidoc/beneficiaries/{beneficiaryId}/inactive para inativar.
+ * 3. PUT /api/rapidoc/beneficiaries/{beneficiaryId}/reactivate deve retornar sucesso.
+ * 4. GET /api/rapidoc/beneficiaries/cpf/{cpf} confirma a reativação.
+ * 5. Repetir PUT para validar idempotência (pode retornar 409/422).
+ */
 
-export async function PUT(request: Request, { params }: { params: { beneficiaryId: string } }) {
-  let payload: unknown = {};
+import axios from 'axios';
+import { NextRequest, NextResponse } from 'next/server';
+import { reactivateBeneficiary } from '@/lib/rapidocService';
 
-  try {
-    const rawBody = await request.text();
-    payload = rawBody ? JSON.parse(rawBody) : {};
-  } catch (error) {
-    console.error('[rapidoc/reactivate] Failed to parse body', error);
-    payload = {};
+const jsonError = (hint: string, status: number, message: string, upstream: unknown = null) =>
+  NextResponse.json(
+    {
+      hint,
+      upstreamStatus: status,
+      message,
+      upstream: typeof upstream === 'string' ? upstream : upstream ?? null,
+    },
+    { status },
+  );
+
+export async function PUT(_request: NextRequest, ctx: { params: Promise<{ beneficiaryId: string }> }) {
+  const { beneficiaryId } = await ctx.params;
+  const trimmed = beneficiaryId?.trim();
+
+  if (!trimmed) {
+    return jsonError('beneficiary_missing', 400, 'beneficiaryId é obrigatório.');
   }
 
-  const { data } = await rapidoc.put(`/beneficiaries/${params.beneficiaryId}/reactivate`, payload);
-  return NextResponse.json(data);
+  try {
+    const data = await reactivateBeneficiary(trimmed);
+    return NextResponse.json(data);
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status && error.response.status !== 200 ? error.response.status : 500;
+      const upstreamStatus = error.response?.status ?? 500;
+      const upstreamData = error.response?.data;
+      const message = error.response?.data?.message || error.message || 'unknown error';
+      return NextResponse.json(
+        {
+          hint: 'rapidoc-reactivate',
+          upstreamStatus,
+          message,
+          upstream: typeof upstreamData === 'string' ? upstreamData : upstreamData ?? null,
+        },
+        { status },
+      );
+    }
+
+    const message = error instanceof Error ? error.message : 'unknown error';
+    return jsonError('rapidoc-reactivate', 500, message);
+  }
 }

--- a/src/app/api/rapidoc/beneficiaries/[beneficiaryId]/referrals/route.ts
+++ b/src/app/api/rapidoc/beneficiaries/[beneficiaryId]/referrals/route.ts
@@ -1,7 +1,20 @@
-import { NextResponse } from "next/server";
+/**
+ * Testes (Postman):
+ * 1. Criar beneficiário via checkout finalizado.
+ * 2. GET /api/rapidoc/beneficiaries/{beneficiaryId}/referrals (placeholder) retorna mensagem.
+ * 3. Ajustar conforme necessidade futura.
+ * 4. Confirmar resolução do parâmetro dinâmico.
+ * 5. --
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
 
 type Params = { beneficiaryId: string };
 
-export async function GET(request: Request, context: { params: Params }) {
-  return NextResponse.json({ message: "Listar encaminhamentos nao implementado", beneficiaryId: context.params.beneficiaryId });
+export async function GET(_request: NextRequest, ctx: { params: Promise<Params> }) {
+  const { beneficiaryId } = await ctx.params;
+  return NextResponse.json({
+    message: 'Listar encaminhamentos nao implementado',
+    beneficiaryId,
+  });
 }

--- a/src/app/api/rapidoc/beneficiaries/cpf/[cpf]/route.ts
+++ b/src/app/api/rapidoc/beneficiaries/cpf/[cpf]/route.ts
@@ -1,15 +1,104 @@
+/**
+ * Testes (Postman):
+ * 1. Criar pagamento no Asaas e obter o paymentId.
+ * 2. Confirmar pagamento e garantir status RECEIVED/CONFIRMED.
+ * 3. POST /api/checkout/finalizar com { paymentId, cpf }.
+ * 4. GET /api/rapidoc/beneficiaries/cpf/{cpf} deve retornar o beneficiário.
+ * 5. Repetir GET para validar idempotência.
+ */
+
+import axios from 'axios';
 import { NextRequest, NextResponse } from 'next/server';
 import rapidoc from '@/lib/rapidoc';
+import { getBeneficiaryByCPF, sanitizeCPF } from '@/lib/rapidocService';
 
+const jsonError = (hint: string, status: number, message: string, upstream: unknown = null) =>
+  NextResponse.json(
+    {
+      hint,
+      upstreamStatus: status,
+      message,
+      upstream: typeof upstream === 'string' ? upstream : upstream ?? null,
+    },
+    { status },
+  );
 
-export async function GET(_: NextRequest, { params }: { params: { cpf: string } }) {
-const { data } = await rapidoc.get(`/beneficiaries/${params.cpf}`);
-return NextResponse.json(data);
+const handleUpstreamError = (error: unknown, hint: string) => {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status && error.response.status !== 200 ? error.response.status : 500;
+    const upstreamStatus = error.response?.status ?? 500;
+    const upstreamData = error.response?.data;
+    const message =
+      (typeof upstreamData === 'object' && upstreamData !== null
+        ? ((upstreamData as Record<string, unknown>).message as string | undefined)
+        : undefined) ||
+      (typeof upstreamData === 'object' && upstreamData !== null && 'error' in upstreamData
+        ? ((upstreamData as { error?: Record<string, unknown> }).error?.message as string | undefined)
+        : undefined) ||
+      error.message ||
+      'unknown error';
+
+    return NextResponse.json(
+      {
+        hint,
+        upstreamStatus,
+        message,
+        upstream: typeof upstreamData === 'string' ? upstreamData : upstreamData ?? null,
+      },
+      { status },
+    );
+  }
+
+  const message = error instanceof Error ? error.message : 'unknown error';
+  return jsonError(hint, 500, message);
+};
+
+type HintedError = { hint?: string; status?: number };
+const isHintedError = (value: unknown): value is HintedError =>
+  typeof value === 'object' && value !== null && 'hint' in value;
+
+export async function GET(_request: NextRequest, ctx: { params: Promise<{ cpf: string }> }) {
+  const { cpf } = await ctx.params;
+  const digits = sanitizeCPF(cpf);
+
+  if (digits.length !== 11) {
+    return jsonError('cpf_invalid', 400, 'CPF deve conter 11 dígitos.');
+  }
+
+  try {
+    const beneficiary = await getBeneficiaryByCPF(digits);
+    return NextResponse.json(beneficiary);
+  } catch (error) {
+    if (isHintedError(error) && error.hint === 'rapidoc-cpf-not-found') {
+      const status = error.status ?? 404;
+      return jsonError('rapidoc-cpf-not-found', status, 'Beneficiário não encontrado.', error);
+    }
+
+    return handleUpstreamError(error, 'rapidoc-get');
+  }
 }
 
+export async function PUT(request: NextRequest, ctx: { params: Promise<{ cpf: string }> }) {
+  const { cpf } = await ctx.params;
+  const digits = sanitizeCPF(cpf);
 
-export async function PUT(req: NextRequest, { params }: { params: { cpf: string } }) {
-const body = await req.json();
-const { data } = await rapidoc.put(`/beneficiaries/${params.cpf}`, body);
-return NextResponse.json(data);
+  if (digits.length !== 11) {
+    return jsonError('cpf_invalid', 400, 'CPF deve conter 11 dígitos.');
+  }
+
+  let payload: unknown = {};
+  try {
+    payload = await request.json();
+  } catch (error) {
+    console.warn('[rapidoc/beneficiaries/cpf] failed to parse body', error);
+    payload = {};
+  }
+
+  try {
+    const { data } = await rapidoc.put(`/beneficiaries/cpf/${digits}`, payload);
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('[rapidoc/beneficiaries/cpf] update failed', digits, error);
+    return handleUpstreamError(error, 'rapidoc-update');
+  }
 }

--- a/src/lib/rapidocService.ts
+++ b/src/lib/rapidocService.ts
@@ -1,3 +1,13 @@
+/**
+ * Testes (Postman):
+ * 1. Criar pagamento no Asaas e obter o paymentId.
+ * 2. Confirmar pagamento no sandbox e aguardar status RECEIVED/CONFIRMED.
+ * 3. GET /api/checkout/status/{paymentId} para validar o status.
+ * 4. POST /api/checkout/finalizar com { paymentId, cpf } e verificar ensured.uuid.
+ * 5. GET /api/rapidoc/beneficiaries/cpf/{cpf} para confirmar o beneficiário ativo.
+ */
+
+import axios, { AxiosRequestConfig } from 'axios';
 import rapidoc from '@/lib/rapidoc';
 
 export type BeneficiaryInput = {
@@ -16,37 +26,160 @@ export type BeneficiaryInput = {
   general?: string;
 };
 
+const nextLogId = () => Math.random().toString(36).slice(2, 10);
+const logDataPreview = (value: unknown) => {
+  if (value == null) {
+    return 'null';
+  }
+
+  try {
+    const serialized = typeof value === 'string' ? value : JSON.stringify(value);
+    return serialized.length > 400 ? `${serialized.slice(0, 400)}…` : serialized;
+  } catch (_error) {
+    return '[unserializable]';
+  }
+};
+
+const buildBodySize = (value: unknown) => {
+  if (value == null) {
+    return 0;
+  }
+
+  try {
+    const serialized = typeof value === 'string' ? value : JSON.stringify(value);
+    return Buffer.byteLength(serialized, 'utf8');
+  } catch (_error) {
+    return 0;
+  }
+};
+
+const logRequest = (id: string, op: string, url: string, body?: unknown) => {
+  const size = buildBodySize(body);
+  console.info(`[rapidoc:srv:req:${id}] op=${op} url=${url} bodySize=${size}`);
+};
+
+const logResponse = (id: string, status: number, start: number) => {
+  console.info(`[rapidoc:srv:res:${id}] status=${status} ms=${Date.now() - start}`);
+};
+
+const logError = (id: string, status: number | string, start: number, data: unknown) => {
+  console.error(
+    `[rapidoc:srv:err:${id}] status=${status} ms=${Date.now() - start} data=${logDataPreview(data)}`,
+  );
+};
+
+export const sanitizeCPF = (cpf: string) => cpf.replace(/\D/g, '');
+
+type HintedError = { hint?: string; status?: number };
+const isHintedError = (value: unknown): value is HintedError =>
+  typeof value === 'object' && value !== null && 'hint' in value;
+
+const attemptGet = async <T>(op: string, url: string, config?: AxiosRequestConfig<unknown>): Promise<T> => {
+  const id = nextLogId();
+  const start = Date.now();
+  const requestPayload: unknown = config?.data ?? config?.params ?? null;
+  logRequest(id, op, url, requestPayload);
+
+  try {
+    const response = await rapidoc.get<T>(url, config);
+    logResponse(id, response.status, start);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status ?? 'ERR';
+      logError(id, status, start, error.response?.data ?? error.message);
+    } else {
+      logError(id, 'ERR', start, error instanceof Error ? error.message : error);
+    }
+
+    throw error;
+  }
+};
+
 export async function getBeneficiaryByCPF(cpf: string) {
-  const response = await rapidoc.get(`/beneficiaries/${cpf}`);
-  return response.data;
+  const digits = sanitizeCPF(cpf);
+  const attempts: Array<() => Promise<unknown>> = [
+    () => attemptGet('getByCPF', `/beneficiaries/cpf/${digits}`),
+    () => attemptGet('getByCPF', '/beneficiaries', { params: { cpf: digits } }),
+    () => attemptGet('getByCPF', `/beneficiaries/document/${digits}`),
+  ];
+
+  for (const attempt of attempts) {
+    try {
+      const data = await attempt();
+      if (Array.isArray(data)) {
+        return data[0];
+      }
+      return data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw { status: 404, hint: 'rapidoc-cpf-not-found' } satisfies HintedError;
 }
 
 export async function createBeneficiaryOne(payload: BeneficiaryInput) {
-  const response = await rapidoc.post('/beneficiaries', [payload]);
-  const data = Array.isArray(response.data) ? response.data[0] : response.data;
-  const uuid = data?.uuid || data?.id;
-  return { raw: data, uuid };
-}
+  const id = nextLogId();
+  const start = Date.now();
+  const url = '/beneficiaries';
+  logRequest(id, 'create', url, [payload]);
 
-export async function reactivateBeneficiary(
-  beneficiaryId: string,
-  payload: BeneficiaryInput,
-) {
-  const response = await rapidoc.put(`/beneficiaries/${beneficiaryId}/reactivate`, payload);
-  return response.data;
+  try {
+    const response = await rapidoc.post(url, [payload]);
+    logResponse(id, response.status, start);
+    const data = Array.isArray(response.data) ? response.data[0] : response.data;
+    const uuid = data?.uuid ?? data?.id;
+    return { uuid, raw: data };
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status ?? 'ERR';
+      logError(id, status, start, error.response?.data ?? error.message);
+    } else {
+      logError(id, 'ERR', start, error instanceof Error ? error.message : error);
+    }
+    throw error;
+  }
 }
 
 export async function ensureBeneficiaryByCPF(payload: BeneficiaryInput) {
   try {
-    const found = await getBeneficiaryByCPF(payload.cpf);
-    const uuid = found?.uuid || found?.id;
-    return { uuid, created: false, data: found };
-  } catch (error: any) {
-    const status = error?.response?.status;
-    if (status === 404) {
+    const existing = await getBeneficiaryByCPF(payload.cpf);
+    const uuid = existing?.uuid ?? existing?.id;
+    return { uuid, created: false, raw: existing };
+  } catch (error) {
+    if (isHintedError(error) && error.hint === 'rapidoc-cpf-not-found') {
       const { uuid, raw } = await createBeneficiaryOne(payload);
-      return { uuid, created: true, data: raw };
+      return { uuid, created: true, raw };
     }
+    throw error;
+  }
+}
+
+export async function reactivateBeneficiary(uuid: string) {
+  const id = nextLogId();
+  const start = Date.now();
+  const url = `/beneficiaries/${uuid}/reactivate`;
+  logRequest(id, 'reactivate', url, {});
+
+  try {
+    const response = await rapidoc.put(url, {});
+    logResponse(id, response.status, start);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status ?? 'ERR';
+      logError(id, status, start, error.response?.data ?? error.message);
+      if (status === 409 || status === 422) {
+        return error.response?.data;
+      }
+    } else {
+      logError(id, 'ERR', start, error instanceof Error ? error.message : error);
+    }
+
     throw error;
   }
 }

--- a/src/types/checkout.ts
+++ b/src/types/checkout.ts
@@ -1,4 +1,13 @@
-﻿export type BillingType = 'BOLETO' | 'CREDIT_CARD' | 'UNDEFINED' | 'PIX';
+/**
+ * Testes (Postman):
+ * 1. Criar pagamento no Asaas e obter o paymentId.
+ * 2. Confirmar pagamento no sandbox (RECEIVED/CONFIRMED).
+ * 3. GET /api/checkout/status/{paymentId} valida status.
+ * 4. POST /api/checkout/finalizar com { paymentId, cpf }.
+ * 5. GET /api/rapidoc/beneficiaries/cpf/{cpf} confirma beneficiário.
+ */
+
+export type BillingType = 'BOLETO' | 'CREDIT_CARD' | 'UNDEFINED' | 'PIX';
 
 export type CheckoutRequestBody = {
   billingType: BillingType;
@@ -73,8 +82,8 @@ export type StatusResponse = {
 };
 
 export type FinalizeRequestBody = {
-  cpf: string;
-  paymentId: string;
+  cpf?: string;
+  paymentId?: string;
 };
 
 export type FinalizeResponseBody = {
@@ -83,7 +92,7 @@ export type FinalizeResponseBody = {
     uuid: string;
     created: boolean;
   } | null;
-  status: string;
+  status?: string;
 };
 
 export const PAYMENT_SUCCESS_STATUSES = ['RECEIVED', 'CONFIRMED'] as const;


### PR DESCRIPTION
## Summary
- rework the checkout finalize API to resolve CPF, ensure Rapidoc beneficiaries by CPF, and persist payment/user state idempotently
- add reusable Rapidoc service helpers with detailed logging and CPF sanitization fallbacks
- update all dynamic Next.js API routes and the manual checkout UI to await params, validate inputs, and surface server hints

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68e347e9247c8328a7ca5cedb2b5c04f